### PR TITLE
added to README installation and troubleshooting instructions

### DIFF
--- a/bulk_RNASeq/README.md
+++ b/bulk_RNASeq/README.md
@@ -83,6 +83,10 @@ Emily Flynn
 
 Al Latif
 
+Amadeo Mazzara
+
+Tammie Tam
+
 Daniel Bunis
 
 Walter Eckalbar


### PR DESCRIPTION
To the bulk-RNAseq README, I added instructions on installing java and nextflow to the Installation section. Instructions on how to resume a run was added for both HPC and Local Usage section. I created a new Troubleshooting section to guide users on how to adjust memory configs.