### PR TITLE
Misc Run Setup: Add freecycle, adjust default errorStrategy, and fix resume/cleanup

### DIFF
--- a/single_cell_RNAseq/README.md
+++ b/single_cell_RNAseq/README.md
@@ -75,7 +75,7 @@ However, if the pipeline fails, the directory is left in place. Please deleted t
 `cp example-inputs/param_2.json example-inputs/my_toy_config.json`
 
 5. Open the run's config file and edit the first two directiories to point to `${TOY_PROJECT_DIR}`, and `${TOY_PROJECT_DIR}/freemuxlet_data/` respectively. The third should point to the directory this repository is in, specifically the subdirectory: `${DATA_PROCESSING_PIPELINE_REPO}/single_cell_RNAseq/example-inputs/`
-6. Submit the run. Note we are using `-profile test` for these test data because they are much smaller. Be sure to remove this flag for any real run as it scales down the resources requested for each task to levels that are not viable for real data.
+6. Submit the run. Note we are using `-profile test` for these test data because they are much smaller. Be sure to remove this flag for any real run as it scales down the resources requested for each task to levels that are not viable for real data. Note that a test run will use the freecycle partition (see more on partitions in additional details).
 `sbatch run.sh example-inputs/my_toy_config.json pre_qc -profile test`
 
 ## Additional Details
@@ -93,6 +93,11 @@ However, if the pipeline fails, the directory is left in place. Please deleted t
 In addition to being used as the initial values for your 'qc_cuts.csv', the values in the file pointed to by your config file's "default_qc_cuts_dir" & "default_qc_cuts_file" elements also determine where initial lines are drawn in QC plots output by the `pre_qc` and `pre_fmx_qc` steps.
 
 Of note, it can be useful to adjust these values sensibly before / for all runs by adjusting this file.  This can be especially useful with tissue data where it is often useful to compare across libraries and batches, with consistent cutoff values, as a method of assessing relative quality across the entire project.
+
+### c4 partitions, additional configuration
+We have the following partitions available on the c4 cluster for DSCoLab members: krummellab,common (default partitions, which are set in the environment variable `$SBATCH_PARTITION`) and freecycle. Freecycle allows us to run jobs on any compute that is not in use (24h job max), with the caveat that the job may be cancelled if a partition owner requires these resources. We have set the default for `test` jobs to freecycle, and for standard jobs to `freecycle,krummellab,common`, which means they are first submitted to freecycle, then krummellab, then common. You may want to adjust this and other cluster options, such as the errorStrategy (what happens to the whole pipeline when it errors). See comments in `nextflow.config` describing what we have set as defaults, and what you may want to adjust.
+
+
 
 ### Data Generation
 

--- a/single_cell_RNAseq/config/compute.config
+++ b/single_cell_RNAseq/config/compute.config
@@ -69,6 +69,8 @@ profiles {
     process {
       time = '2h'
       memory='10GB'
+      queue = 'freecycle'
+      errorStrategy = 'terminate'
       withName: 'CELLRANGER'{
         memory='100GB'
         cpus=4

--- a/single_cell_RNAseq/config/compute.config
+++ b/single_cell_RNAseq/config/compute.config
@@ -30,8 +30,8 @@ profiles {
       }
       withName: "FILTER_BAM" {
         cpus=5
-	      memory='250GB'
-	      time='8h'
+	memory='250GB'
+	time='8h'
       }
       withName: "FREEMUXLET_POOL"{
         cpus=10

--- a/single_cell_RNAseq/nextflow.config
+++ b/single_cell_RNAseq/nextflow.config
@@ -1,10 +1,25 @@
 process.executor = 'slurm'
 process.cache = 'lenient'
-process.clusterOptions = '-x c4-n20'
 process.publishDir.mode='copy'
 process.publishDir.overwrite = true
 singularity.enabled = true
 singularity.autoMounts = true
+
+// cluster options you may want to edit
+process.queue = 'freecycle,krummellab,common'
+process.$test.queue = 'freecycle'
+process.clusterOptions = '-x c4-n20' // skip c4-n20, you can add to this  listif there are other problem nodes, or remove c4-n20 if it is working thatt day
+executor.queueSize = 60 // max number of jobs that can be submitted to the queue
+ 
+process.errorStrategy = 'finish' // if there is an error, finish all submitted jobs before killing things -- helps prevent loss of compute time for large sets of jobs
+process.$test.errorStrategy = 'terminate' // immediately stop if there is an error in a test job, helps with fast debugging
+
+// additional options to consider - note that there can only be one error strategy selected for the standard profile, so you must comment out the other `process.errorStrategy` if you are changing this
+// process.errorStrategy = 'ignore' // the pipeline will continue even when a particular file errors out (particularly useful in the case you have a large number of files running and you expect some files may fail. This is not our default because it allows for "silent" errors, but you can use this, just make sure to check all completes.)
+// process.errorStrategy = 'retry' // retry each process once on each instance (data item) if it errors out 
+// process.maxRetries = 1 // can increase - number for each process instance, uncomment if using "retry"
+// process.maxErrors = 3 // number of times a process can error across all instances of that process, recommended to uncomment if using "retry"
+
 
 params {
 

--- a/single_cell_RNAseq/nextflow.config
+++ b/single_cell_RNAseq/nextflow.config
@@ -7,12 +7,12 @@ singularity.autoMounts = true
 
 // cluster options you may want to edit
 process.queue = 'freecycle,krummellab,common'
-process.$test.queue = 'freecycle'
+
 process.clusterOptions = '-x c4-n20' // skip c4-n20, you can add to this  listif there are other problem nodes, or remove c4-n20 if it is working thatt day
 executor.queueSize = 60 // max number of jobs that can be submitted to the queue
  
 process.errorStrategy = 'finish' // if there is an error, finish all submitted jobs before killing things -- helps prevent loss of compute time for large sets of jobs
-process.$test.errorStrategy = 'terminate' // immediately stop if there is an error in a test job, helps with fast debugging
+
 
 // additional options to consider - note that there can only be one error strategy selected for the standard profile, so you must comment out the other `process.errorStrategy` if you are changing this
 // process.errorStrategy = 'ignore' // the pipeline will continue even when a particular file errors out (particularly useful in the case you have a large number of files running and you expect some files may fail. This is not our default because it allows for "silent" errors, but you can use this, just make sure to check all completes.)

--- a/single_cell_RNAseq/pipeline_post_fmx_qc.nf
+++ b/single_cell_RNAseq/pipeline_post_fmx_qc.nf
@@ -2,6 +2,16 @@
 
 nextflow.enable.dsl=2
 
+workflow.onComplete {
+    println "Pipeline completed at: $workflow.complete"
+    println "Execution status: ${ workflow.success ? 'OK' : 'failed' }"
+    if (workflow.success){
+       println "Deleting working directory $workDir"
+       "rm -rf $workDir".execute()
+    }
+}
+
+
 include { 
 SEURAT_PRE_FMX_FILTER;
 FILTER_BARCODES;

--- a/single_cell_RNAseq/pipeline_post_qc.nf
+++ b/single_cell_RNAseq/pipeline_post_qc.nf
@@ -1,6 +1,16 @@
 
 nextflow.enable.dsl=2
 
+workflow.onComplete {
+    println "Pipeline completed at: $workflow.complete"
+    println "Execution status: ${ workflow.success ? 'OK' : 'failed' }"
+    if (workflow.success){
+       println "Deleting working directory $workDir"
+       "rm -rf $workDir".execute()
+    }
+}
+
+
 include { 
     SEURAT_POST_FILTER
 } from './modules/pipeline_tasks.nf'

--- a/single_cell_RNAseq/pipeline_pre_fmx_qc.nf
+++ b/single_cell_RNAseq/pipeline_pre_fmx_qc.nf
@@ -1,5 +1,15 @@
 nextflow.enable.dsl=2
 
+workflow.onComplete {
+    println "Pipeline completed at: $workflow.complete"
+    println "Execution status: ${ workflow.success ? 'OK' : 'failed' }"
+    if (workflow.success){
+       println "Deleting working directory $workDir"
+       "rm -rf $workDir".execute()
+    }
+}
+
+
 // This pipeline expects the following to be provided in json form on the command line
 /* params.project_dir  
  * params.pools is a list of pools

--- a/single_cell_RNAseq/pipeline_pre_qc.nf
+++ b/single_cell_RNAseq/pipeline_pre_qc.nf
@@ -1,5 +1,15 @@
 nextflow.enable.dsl=2
 
+workflow.onComplete {
+    println "Pipeline completed at: $workflow.complete"
+    println "Execution status: ${ workflow.success ? 'OK' : 'failed' }"
+    if (workflow.success){
+       println "Deleting working directory $workDir"
+       "rm -rf $workDir".execute()
+    }
+}
+
+
 // Processes
 
 include {

--- a/single_cell_RNAseq/run.sh
+++ b/single_cell_RNAseq/run.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 #SBATCH --nodes=1
 #SBATCH --ntasks=1
-#SBATCH --mem=15G
-#SBATCH --time=24:00:00
+#SBATCH --mem=2G
+#SBATCH --time=7-00:00:00
 #SBATCH --output=/krummellab/data1/%u/logs/scseq_nf_%j.log
 #SBATCH --partition=krummellab,common
 

--- a/single_cell_RNAseq/run.sh
+++ b/single_cell_RNAseq/run.sh
@@ -49,6 +49,8 @@ if [ "$failed" = true ];
 then
   exit 1
 else
+    unset SBATCH_PARTITION
+
     # create a working directory
     nf_work=/c4/scratch/${USER}/nextflow/${SLURM_JOB_ID}/
     mkdir -p $nf_work

--- a/single_cell_RNAseq/run.sh
+++ b/single_cell_RNAseq/run.sh
@@ -14,23 +14,12 @@
 # $2 is the step of the pipeline you are running, must be one of "pre_qc", "post_qc", "pre_fmx_qc", "post_fmx_qc"
 # then pass as many additional arguments to nextflow as you'd like (e.g. -with-timeline, -profile test)
 
-function cleanup()
-{
-    if [ $? -eq 0 ]
-    then
-    echo "step complete done, deleting working directory"
-    nf_work=/c4/scratch/${USER}/nextflow/${SLURM_JOB_ID}/
-    rm -rf ${nf_work}
-    fi
-}
-trap cleanup EXIT
 
-
-# check on arguments
-failed=false
 PARAM_FILE=$1
 STEP=$2
 
+# check on arguments
+failed=false
 if [ ! -f "$PARAM_FILE" ];
 then
  echo "Parameter file does not exist"

--- a/single_cell_RNAseq/run_resume.sh
+++ b/single_cell_RNAseq/run_resume.sh
@@ -61,7 +61,8 @@ if [ "$failed" = true ];
 then
   exit 1
 else
-#    mkdir -p $nf_work
+    unset SBATCH_PARTITION
+
     export NXF_WORK=${nf_work}
 
     # run the pipeline

--- a/single_cell_RNAseq/run_resume.sh
+++ b/single_cell_RNAseq/run_resume.sh
@@ -15,25 +15,14 @@
 # $3 is the JOB_ID of the main run that you want to resume
 # then pass as many additional arguments to nextflow as you'd like (e.g. -with-timeline, -profile test, etc.)
 
-function cleanup()
-{   
-    if [ $? -eq 0 ]
-    then
-	echo "COMPLETED on a resume! Please delete the working directory"
-    else 
-	echo "FAILED with exit code $?"
-    fi
-}
-trap cleanup EXIT
-
-export NXF_JAVA_HOME="/krummellab/data1/erflynn/software/java/jdk-17.0.5"
-export PATH=$PATH:/krummellab/data1/erflynn/software/nextflow/22.10.4_build_5836/
-
-# check on arguments
-failed=false
 PARAM_FILE=$1
 STEP=$2
 PREV_JOB_ID=$3
+
+
+
+# check on arguments
+failed=false
 
 if [ ! -f "$PARAM_FILE" ]; 
 then

--- a/single_cell_RNAseq/run_resume.sh
+++ b/single_cell_RNAseq/run_resume.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 #SBATCH --nodes=1
 #SBATCH --ntasks=1
-#SBATCH --mem=15G
-#SBATCH --time=48:00:00
+#SBATCH --mem=2G
+#SBATCH --time=7-00:00:00
 #SBATCH --output=/krummellab/data1/%u/logs/scseq_nf_resume_%j.log
 #SBATCH --partition=krummellab,common
 
@@ -61,12 +61,10 @@ if [ "$failed" = true ];
 then
   exit 1
 else
-    # create a working directory
-
 #    mkdir -p $nf_work
     export NXF_WORK=${nf_work}
 
     # run the pipeline
-    nextflow run pipeline_${STEP}.nf -c tool.config -params-file $PARAM_FILE -resume "${@:4}" 
+    nextflow run pipeline_${STEP}.nf -params-file $PARAM_FILE -resume "${@:4}" 
 fi
 


### PR DESCRIPTION
This PR addresses several feature requests and modifications in the run script and configuration for the single cell pipeline.
Specifically:

- #47 **Fix run_resume.sh script.** This just had not been updated to match the run.sh 
- #41 **Deletes working directory if OOT error** This was a slightly tricky bug. Basically, if the parent run.sh script is cancelled by the external system vs by an internal error, it has a parent error of 0 even if subprocesses do not have this. To fix this, I moved the working directory deletion from the run script to the individual steps using the `workflow.onComplete` directive from nextflow.
- #50 **Get nextflow to submit to specified partition** @dtm2451 solved this with unset SBATCH_PARTITION, and I implemented by adding this to the run scripts and the config. I set default to freecycle for test, and then to freecycle,krummellab,common for standard runs. 
- #43 **Check if we can set a limit to resources consumed by nextflow** I set the max number of jobs to 60. I could not find an option to set the max number of cpus for SLURM (can be set for local). We may want to lower this number.
- I have also changed the **default errorStrategy** to "finish" instead of "terminate" (so that existing steps aren't interrupted if something fails), and included additional comments about how to modify this if another strategy (e.g. ignore, retry) if desired.
