### PR TITLE
Test hotfix

### DIFF
--- a/single_cell_RNAseq/README.md
+++ b/single_cell_RNAseq/README.md
@@ -133,7 +133,7 @@ To run regression tests:
 
 `cd single_cell_RNAseq`
 
-`nf-test test tests/pipeline_pre_qc.nf.test --without-trace`
+`/krummellab/data1/software/bin/nf-testtest tests/pipeline_pre_qc.nf.test --without-trace`
 
 #### How do the tests work
 

--- a/single_cell_RNAseq/modules/pipeline_tasks.nf
+++ b/single_cell_RNAseq/modules/pipeline_tasks.nf
@@ -593,8 +593,6 @@ process SEURAT_ADD_TCR {
 process SEURAT_QC {
   publishDir "${params.project_dir}/data/single_cell_GEX/logs/${library}/", mode: 'copy', pattern: ".command.log", saveAs: { filename -> "seurat_qc.log" }
   publishDir "${params.project_dir}/data/single_cell_GEX/processed/${library}/automated_processing", mode: 'copy', pattern: "${library}*"
-  // For testing
-  publishDir "${workDir}/data/single_cell_GEX/processed/${library}/automated_processing", mode: 'copy', pattern: "${library}*"
 
   container "${params.container.rsinglecell}"
   containerOptions "-B ${params.settings.default_qc_cuts_dir}"

--- a/single_cell_RNAseq/tests/pipeline_pre_qc.nf.test
+++ b/single_cell_RNAseq/tests/pipeline_pre_qc.nf.test
@@ -5,7 +5,6 @@ nextflow_pipeline {
     tag "qc-quantiles"
 
     def c4PathToTestFiles = "/krummellab/data1/integration_test_user/tutorial_lib_sep"
-    def freemuxDir = c4PathToTestFiles + "/freemuxlet_data"
 
     stage {
         copy c4PathToTestFiles
@@ -15,12 +14,12 @@ nextflow_pipeline {
 
         def meta = "$metaDir"
         def testDirAbsolute = meta + c4PathToTestFiles
-        def projectDir = "meta" + c4PathToTestFiles
+        def freemuxDir = testDirAbsolute + "/freemuxlet_data"
 
         when {
             params {
                     load("./tests/inputs/pre_qc.json")
-                    project_dir = projectDir
+                    project_dir = testDirAbsolute
                     settings = {
                         add_tcr = false
                         add_bcr = false
@@ -55,12 +54,12 @@ nextflow_pipeline {
 
         def meta = "$metaDir"
         def testDirAbsolute = meta + c4PathToTestFiles
-        def projectDir = "meta" + c4PathToTestFiles
+        def freemuxDir = testDirAbsolute + "/freemuxlet_data"
 
         when {
             params {
                 load("./tests/inputs/pre_qc.json")
-                project_dir = projectDir
+                project_dir = testDirAbsolute
                 settings = {
                     add_tcr = false
                     add_bcr = false
@@ -95,12 +94,12 @@ nextflow_pipeline {
 
         def meta = "$metaDir"
         def testDirAbsolute = meta + c4PathToTestFiles
-        def projectDir = "meta" + c4PathToTestFiles
+        def freemuxDir = testDirAbsolute + "/freemuxlet_data"
 
         when {
             params {
                 load("./tests/inputs/pre_qc.json")
-                project_dir = projectDir
+                project_dir = testDirAbsolute
                 settings = {
                         add_tcr = false
                         add_bcr = false
@@ -136,12 +135,12 @@ nextflow_pipeline {
 
         def meta = "$metaDir"
         def testDirAbsolute = meta + c4PathToTestFiles
-        def projectDir = "meta" + c4PathToTestFiles
+        def freemuxDir = testDirAbsolute + "/freemuxlet_data"
 
         when {
             params {
                 load("./tests/inputs/pre_qc.json")
-                project_dir = projectDir
+                project_dir = testDirAbsolute
                 settings = {
                         add_tcr = false
                         add_bcr = false
@@ -176,12 +175,12 @@ nextflow_pipeline {
 
         def meta = "$metaDir"
         def testDirAbsolute = meta + c4PathToTestFiles
-        def projectDir = "meta" + c4PathToTestFiles
+        def freemuxDir = testDirAbsolute + "/freemuxlet_data"
 
         when {
             params {
                 load("./tests/inputs/pre_qc.json")
-                project_dir = projectDir
+                project_dir = testDirAbsolute
                 settings = {
                         add_tcr = false
                         add_bcr = false
@@ -215,12 +214,12 @@ nextflow_pipeline {
 
         def meta = "$metaDir"
         def testDirAbsolute = meta + c4PathToTestFiles
-        def projectDir = "meta" + c4PathToTestFiles
+        def freemuxDir = testDirAbsolute + "/freemuxlet_data"
 
         when {
             params {
                 load("./tests/inputs/pre_qc.json")
-                project_dir = projectDir
+                project_dir = testDirAbsolute
                 settings = {
                         add_tcr = false
                         add_bcr = false
@@ -255,12 +254,12 @@ nextflow_pipeline {
 
         def meta = "$metaDir"
         def testDirAbsolute = meta + c4PathToTestFiles
-        def projectDir = "meta" + c4PathToTestFiles
+        def freemuxDir = testDirAbsolute + "/freemuxlet_data"
 
         when {
             params {
                 load("./tests/inputs/pre_qc.json")
-                project_dir = projectDir
+                project_dir = testDirAbsolute
                 settings = {
                             add_tcr = false
                             add_bcr = false
@@ -296,12 +295,12 @@ nextflow_pipeline {
 
         def meta = "$metaDir"
         def testDirAbsolute = meta + c4PathToTestFiles
-        def projectDir = "meta" + c4PathToTestFiles
+        def freemuxDir = testDirAbsolute + "/freemuxlet_data"
 
         when {
             params {
                 load("./tests/inputs/pre_qc.json")
-                project_dir = projectDir
+                project_dir = testDirAbsolute
                     settings = {
                             add_tcr = false
                             add_bcr = false


### PR DESCRIPTION
the pipeline was still publishing artifacts to ` /krummellab/data1/integration_test_user/tutorial_lib_sep/`. This PR explicitly forces all tests to use the absolute path of the meta directory (isolated testing environment).

How to test:

```
cd into single_cell_RNAseq
/krummellab/data1/software/bin/nf-test  test tests/pipeline_pre_qc.nf.test --without-trace
```