### PR TITLE
Bulk rnaseq multiqc per sample

### DIFF
--- a/bulk_RNASeq/config/base.config
+++ b/bulk_RNASeq/config/base.config
@@ -9,6 +9,7 @@ profiles {
         singularity.autoMounts = true
         process.executor = 'local'
         process.cache = 'lenient'
+        executor.cpus = 314
 	    trace.enabled = true
         trace.taskMemory = true
     }

--- a/bulk_RNASeq/config/base.config
+++ b/bulk_RNASeq/config/base.config
@@ -18,7 +18,7 @@ profiles {
         singularity.enabled = true
         singularity.autoMounts = true
         process.executor = 'slurm'
-	    executor.queueSize = 60
+	    executor.queueSize = 24
         process.cache = 'lenient'
 	    trace.enabled = true
         trace.taskMemory = true

--- a/bulk_RNASeq/config/container.config
+++ b/bulk_RNASeq/config/container.config
@@ -7,95 +7,95 @@ process {
 
 
    withLabel: 'fastp_trim_adapters' {
-      cpus = 6
+      cpus = Math.min(6, params.max_cpus_per_job)
    }
 
    withLabel: 'sortmerna_ribosomal_rna_removal' {
-      cpus = 20
+      cpus = Math.min(13, params.max_cpus_per_job)
       time = '72h'
    }
 
    withLabel: 'kallisto_quant' {
-      cpus = 4
+      cpus = Math.min(4, params.max_cpus_per_job)
    }
 
    withLabel: 'star_align' {
-      cpus = 8
+      cpus = Math.min(8, params.max_cpus_per_job)
       time = '72h'
    }
 
    withLabel: 'samtools_sort' {
-      cpus = 2
+      cpus = Math.min(2, params.max_cpus_per_job)
    }
 
    withLabel: 'samtools_index' {
-      cpus = 2
+      cpus = Math.min(2, params.max_cpus_per_job)
    }
 
    withLabel: 'samtools_stats' {
-      cpus = 1
+      cpus = Math.min(1, params.max_cpus_per_job)
    }
 
    withLabel: 'samtools_idxstats' {
-      cpus = 2
+      cpus = Math.min(2, params.max_cpus_per_job)
    }
 
    withLabel: 'samtools_flagstat' {
-      cpus = 2
+      cpus = Math.min(2, params.max_cpus_per_job)
    }
 
    withLabel: 'samtools_extract_mapped_reads' {
-      cpus = 2
+      cpus = Math.min(2, params.max_cpus_per_job)
    }
 
    withLabel: 'samtools_bam_to_cram' {
-      cpus = 2
+      cpus = Math.min(2, params.max_cpus_per_job)
    }
 
    withLabel: 'picard_markduplicates' {
-      cpus = 2
+      cpus = Math.min(2, params.max_cpus_per_job)
    }
 
    withLabel: 'gatk4_splitncigarreads' {
-      cpus = 1
+      cpus = Math.min(1, params.max_cpus_per_job)
       time = '72h'
    }
 
    withLabel: 'gatk4_recalibrator' {
-      cpus = 1
+      cpus = Math.min(1, params.max_cpus_per_job)
    }
 
    withLabel: 'gatk4_apply_bqsr' {
-      cpus = 1
+      cpus = Math.min(1, params.max_cpus_per_job)
       time = '48h'
    }
 
    withLabel: 'gatk4_haplotypecaller' {
-      cpus = 1
+      cpus = Math.min(1, params.max_cpus_per_job)
       time = '148h'
    }
 
    withLabel: 'gatk4_variantfiltration' {
-      cpus = 1
+      cpus = Math.min(1, params.max_cpus_per_job)
    }
 
    withLabel: 'bcftools_contig_conversion' {
-      cpus = 4
+      cpus = Math.min(4, params.max_cpus_per_job)
    }
 
    withLabel: 'bcftools_sort_vcf' {
-      cpus = 1
+      cpus = Math.min(1, params.max_cpus_per_job)
    }
 
    withLabel: 'bcftools_index_vcf' {
-      cpus = 1
+      cpus = Math.min(1, params.max_cpus_per_job)
    }
 
    withLabel: 'bcftools_merge_vcf' {
-      cpus = 8
+      cpus = Math.min(8, params.max_cpus_per_job)
    }
 
    withLabel: 'multiqc' {
-      cpus = 1
+      cpus = Math.min(1, params.max_cpus_per_job)
    }
 }

--- a/bulk_RNASeq/config/parameters.config
+++ b/bulk_RNASeq/config/parameters.config
@@ -1,5 +1,6 @@
 
 params {
+    max_cpus_per_job    = 24
     salmon_quant_libtype= null
     fragment_length_mean= 200
     fragment_length_std = 20
@@ -11,6 +12,7 @@ params {
     gatk_vf_qd_filter   = 2.0
     umitools_dedup_stats= false
     filter_rrna         = true
+    call_snps           = true
     format_contigs      = true
     adapter_sequence_1  = "CTGTCTCTTATACACATCT"
     adapter_sequence_2  = "CTGTCTCTTATACACATCT"

--- a/bulk_RNASeq/modules/bcftools_merge_vcf.nf
+++ b/bulk_RNASeq/modules/bcftools_merge_vcf.nf
@@ -39,7 +39,5 @@ process BCFTOOLS_MERGE_VCF {
         --output merged_snps.bcf \\
         ${vcfs.join(' ')}
         """
-    }
-
-    
+    }    
 }

--- a/bulk_RNASeq/modules/fastp_trim_adapters.nf
+++ b/bulk_RNASeq/modules/fastp_trim_adapters.nf
@@ -20,7 +20,7 @@ process FASTP_TRIM_ADAPTERS {
 
     output:
     tuple val(meta), path("*.fastp.fastq.gz") , emit: trimmed_reads
-    path("*.fastp.json")                      , emit: json_report
+    tuple val(meta), path("*.fastp.json")     , emit: json_report
     path("*.fastp.html")                      , emit: html_report
 
     when:

--- a/bulk_RNASeq/modules/gatk4_haplotype_caller.nf
+++ b/bulk_RNASeq/modules/gatk4_haplotype_caller.nf
@@ -19,6 +19,8 @@ process GATK4_HAPLOTYPECALLER {
     output:
     tuple val(meta), path("*.vcf.gz"), emit: vcf
     tuple val(meta), path("*.tbi")   , optional:true, emit: tbi
+    tuple val(meta), path("*.variant_calling_detail_metrics"), emit: detail_metrics
+    tuple val(meta), path("*.variant_calling_summary_metrics"), emit: summary_metrics
 
     when:
     task.ext.when == null || task.ext.when
@@ -36,5 +38,11 @@ process GATK4_HAPLOTYPECALLER {
         $dbsnp_command \\
         --tmp-dir \$PWD \\
         $args
+
+    gatk --java-options "-Xmx${task.memory.toGiga()}G" \\
+        CollectVariantCallingMetrics \\
+        --DBSNP $known_sites \\
+        --INPUT ${prefix}.vcf.gz \\
+        --OUTPUT ${prefix}
     """
 }

--- a/bulk_RNASeq/modules/kallisto_quant.nf
+++ b/bulk_RNASeq/modules/kallisto_quant.nf
@@ -20,8 +20,8 @@ process KALLISTO_QUANT {
     output:
     tuple val(meta), path("${prefix}.kallisto.abundance.h5") , emit: abundance_h5
     tuple val(meta), path("${prefix}.kallisto.abundance.tsv") , emit: abundance_tsv
-    tuple val(meta), path("${prefix}.kallisto.run_info.json"), emit: json_info, optional: true
-    tuple val(meta), path("${prefix}.kallisto.log"), emit: log, optional: true
+    tuple val(meta), path("${prefix}.kallisto.run_info.json"), emit: run_info
+    tuple val(meta), path("${prefix}.kallisto.log"), emit: log
     
     
     script:
@@ -29,14 +29,14 @@ process KALLISTO_QUANT {
     prefix   = task.ext.prefix ?: "${meta.id}"
     if (meta.single_end) {
         """
-        kallisto quant --index $transcript_index --output-dir ${prefix} -t ${task.cpus} --single -l ${params.fragment_length_mean} -s ${params.fragment_length_std} ${reads} > ${prefix}.kallisto.log
+        kallisto quant --index $transcript_index --output-dir ${prefix} -t ${task.cpus} --single -l ${params.fragment_length_mean} -s ${params.fragment_length_std} ${reads} &> ${prefix}.kallisto.log
         mv ${prefix}/abundance.h5 ${prefix}.kallisto.abundance.h5
         mv ${prefix}/abundance.tsv ${prefix}.kallisto.abundance.tsv
         mv ${prefix}/run_info.json ${prefix}.kallisto.run_info.json
         """
     } else {
         """
-        kallisto quant --index $transcript_index --output-dir ${prefix} -t ${task.cpus} ${reads[0]} ${reads[1]} > ${prefix}.kallisto.log
+        kallisto quant --index $transcript_index --output-dir ${prefix} -t ${task.cpus} ${reads[0]} ${reads[1]} &> ${prefix}.kallisto.log
         mv ${prefix}/abundance.h5 ${prefix}.kallisto.abundance.h5
         mv ${prefix}/abundance.tsv ${prefix}.kallisto.abundance.tsv
         mv ${prefix}/run_info.json ${prefix}.kallisto.run_info.json

--- a/bulk_RNASeq/modules/multiqc_per_sample.nf
+++ b/bulk_RNASeq/modules/multiqc_per_sample.nf
@@ -1,0 +1,28 @@
+process MULTIQC_PER_SAMPLE {
+    tag "$meta.id"
+    publishDir "${params.results_directory}/multiqc_per_sample", mode: 'copy'
+    label 'multiqc_per_sample'
+    memory {
+        // File size in GB
+        fileSize = log_files.size() / (1024 * 1024 * 1024)
+        return 1.GB + (1.GB * fileSize)
+    }
+
+    input:
+    tuple val(meta), path(log_files)
+
+    output:
+    path "*multiqc_report.html", emit: report
+    path "*_data"              , emit: data
+    path "*_plots"             , optional:true, emit: plots
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    multiqc --filename ${prefix}_multiqc_report.html -f $args .
+    """
+}

--- a/bulk_RNASeq/modules/sortmerna_rrna_removal.nf
+++ b/bulk_RNASeq/modules/sortmerna_rrna_removal.nf
@@ -21,7 +21,7 @@ process SORTMERNA_RIBOSOMAL_RNA_REMOVAL {
 
     output:
     tuple val(meta), path("*.sortmerna.fastq.gz"), emit: reads
-    tuple val(meta), path("*.log")     , emit: log
+    tuple val(meta), path("*.sortmerna.log")     , emit: log
 
     when:
     task.ext.when == null || task.ext.when
@@ -40,6 +40,7 @@ process SORTMERNA_RIBOSOMAL_RNA_REMOVAL {
             --aligned rRNA_reads \\
             --fastx \\
             --other non_rRNA_reads \\
+            --log \\
             $args
 
         mv non_rRNA_reads.f*q.gz ${prefix}.sortmerna.fastq.gz
@@ -58,6 +59,7 @@ process SORTMERNA_RIBOSOMAL_RNA_REMOVAL {
             --other non_rRNA_reads \\
             --paired_in \\
             --out2 \\
+            --log \\
             $args
 
         mv non_rRNA_reads_fwd.f*q.gz ${prefix}_R1.sortmerna.fastq.gz


### PR DESCRIPTION
key modifications to the pipeline:
* MultiQC report per sample
   * in addition to a global multiQC report, there is now an individual report for each sample ID
   * reports now include additional metrics from SNP calling 
* Global CPU resource management
   * added `executor.cpus` parameter in `config/base.config` to be able to control maximum allowable number of CPU usage when running under `local` profile i.e. running the pipeline on a local machine or on a developmental (dev) node
   * added `executor.queueSize` parameter in `config/base.config` to be able to control maximum allowable number of jobs to run when running the pipeline on a cluster via slurm 
   * added `max_cpus_per_job` parameter in `config/parameters` to be able to control maximum allowable number of CPU usage per job when running the pipeline on a cluster via slurm
   * the above two additions enable us to control the "ceiling" of number of CPUs the pipeline can use via slurm, preventing the risk of "hogging" C4 resources 
 * Optional SNP calling
    * added `call_snps` parameter in `config/parameters.config` to be able to control whether or not SNP calling process steps need to be carried out. This was requested by the Genomics core and makes sense since these steps have considerably high computational requirements 