### PR TITLE
cap nCount_ADT axis to 25000 in diagnostic plots

### DIFF
--- a/single_cell_RNAseq/bin/seurat_utils.R
+++ b/single_cell_RNAseq/bin/seurat_utils.R
@@ -19,7 +19,12 @@ scatterhist <- function(x, y, sobj, params) {
     geom_hline(yintercept = y_upper) +
     geom_hline(yintercept = y_lower) + 
     geom_rect(aes(xmin=x_lower, xmax=x_upper, ymin=y_lower, ymax=y_upper), color="red", alpha=0) +
-    geom_text(data = data.frame(x=x_lower, y=y_upper,text=paste0(filter_cell_percent, "%")), aes(x=x,y=y,label=text), hjust=0, vjust=1, color="darkred", size=8)
+    geom_text(data = data.frame(x=x_lower, y=y_upper,text=paste0(filter_cell_percent, "%")), aes(x=x,y=y,label=text), hjust=0, vjust=1, color="darkred", size=8) +
+    if (x == "nCount_ADT") {
+      xlim(NA, 25000)
+    } else if (y == "nCount_ADT") {
+      ylim(NA, 25000)
+    }
   
   return( ggExtra::ggMarginal(p, type = "histogram", bins=50) )
 }


### PR DESCRIPTION
Simple update: Uses `x`/`ylim` to enforce [0,25000] as range for "nCount_ADT" axes of diagnostic plots.

Current issue: I've found most of my CITEseq libraries to have handfuls of outlier cells that have values in the hundreds of thousand range for this metric whereas the bulk of most cells will fall into the 1,000-15,000 range.  This common phenomenon causes the bulk of the data to be shrunk into a sliver at the lower end of this axis, which then effectively renders the plots unusable for their intended purpose -- allowing the user dial in a cutoff.  The range of values where a cutoff might be drawn from ends up have very little resolution.

The fix here: This PR adjusts the function used for scatterplot creation to enforce axis limits of 0 to 25,000 for "nCount_ADT"-axes.