### PR TITLE
Isolated and more robust way to activate and use conda environments

### DIFF
--- a/single_cell_RNAseq_snake/README.md
+++ b/single_cell_RNAseq_snake/README.md
@@ -13,27 +13,11 @@ the bio-specimen id by which they were de-multiplexed.
 
 ## Usage
 
-### Step 1 - Module Files
+### Step 1 - Install snakemake conda environment
 
-You must first add `/krummellab/data1/modulefiles` to the env var: `MODULEPATH`.
+`./snakemake_installation.sh`
 
-Confirm it works: `module avail`
-
-You should see the mamba module
-
-```
- module avail
-
-------------------------------------------------- /software/c4/modulefiles/repos --------------------------------------------------
-   CBI    UserContributed    WitteLab
-
--------------------------------------------------- /krummellab/data1/modulefiles --------------------------------------------------
-   mamba 
-
-```
-
-I've created an environment module called mamba, that points to a mamba installation on c4. Mamba is 
-the recommended way to interact and run snakemake.
+This script creates an insolated conda environment called `depool_snakemake` that snakemake can run in.
 
 ### Step 2 - Config
 
@@ -43,8 +27,8 @@ Add your de-multiplexed files as input to: `pipelines/depooling/config.yaml`.
 
 To run a pipeline, use the helper bash script: `./run_snakemake.sh`.
 
-This script:
-- Sets up  a designated `mamba` environment that snakemake runs in. 
+This script: 
+- Activates the `depool_snakemake` conda environment
 - Invokes `run_pipeline.py`
 
 Modify the arguments to `run_pipeline.py` as you like. (See below)

--- a/single_cell_RNAseq_snake/run_snakemake.sh
+++ b/single_cell_RNAseq_snake/run_snakemake.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
-module load mamba
-source /krummellab/data1/software/miniforge3/bin/activate snakehiss
+# must have performed step 1 of USAGE in the README before running this script
+module load CBI miniconda3/23.3.1-0-py39
+# Load  your locally installed mamba environment for running snakemake 
+conda activate depool_snakemake
 python run_pipeline.py depooling --singularity-args "--bind /krummellab/data1/amazzara/tutorial_lib_sep/data/single_cell_GEX/processed/" --local-cores 2
 

--- a/single_cell_RNAseq_snake/snakemake_installation.sh
+++ b/single_cell_RNAseq_snake/snakemake_installation.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# load C4s conda environment
+module load CBI miniconda3/23.3.1-0-py39
+
+# create the a snakemake conda environment
+conda create -n depool_snakemake python=3.11.0
+
+#activate the environment and install mamba
+conda activate depool_snakemake
+conda install -c conda-forge mamba=1.5.8
+
+# install snakemake using mamba
+mamba install snakemake=8.10.7 snakemake-executor-plugin-slurm=0.4.4 -c conda-forge -c bioconda


### PR DESCRIPTION
Using a shared mamba environment created numerous problems. This PR provides a script to create isolated conda environments per user.

Addresses: https://github.com/UCSF-DSCOLAB/data_processing_pipelines/issues/74