### PR TITLE
Separate output for post-demuxlet

### DIFF
--- a/single_cell_RNAseq/bin/find_doublets.R
+++ b/single_cell_RNAseq/bin/find_doublets.R
@@ -43,7 +43,7 @@ genDoubletTable = function(doublet_stats, ncells_loaded, nsamples){
   dbl_rate_10x_loaded = predict(DBL_MODEL_loaded, new=data.frame(num_cells_loaded=ncells_loaded)) / 100
   predicted_recovery = predict(MODEL_recovered, new=data.frame(num_cells_loaded=ncells_loaded))
 
-  num_mx_dbls = ifelse("DBL" %in% rownames(doublet_stats$fmlDropletTypeProp), doublet_stats$fmlDropletTypeProp["DBL",][[1]], 10)
+  num_mx_dbls = ifelse("DBL" %in% rownames(doublet_stats$fmlDropletTypeComp), doublet_stats$fmlDropletTypeComp["DBL",][[1]], 10)
   num_mx_sngs = doublet_stats$fmlDropletTypeComp["SNG",][[1]]
 
   fmlDblRate = num_mx_dbls/(num_mx_sngs+num_mx_dbls)

--- a/single_cell_RNAseq/helpers/params_parse.nf
+++ b/single_cell_RNAseq/helpers/params_parse.nf
@@ -7,7 +7,11 @@ def get_c4_bam(library){
 }
 
 def get_cutoffs(library){
-  return file("${params.project_dir}/data/single_cell_GEX/processed/${library}/automated_processing/${library}_cutoffs.csv", checkIfExists: true)
+    if (params.settings.demux_method.equals("demuxlet")){
+        return file("${params.project_dir}/data/single_cell_GEX/processed/${library}/automated_processing_dmx/${library}_cutoffs.csv", checkIfExists: true)
+    } else {
+        return file("${params.project_dir}/data/single_cell_GEX/processed/${library}/automated_processing/${library}_cutoffs.csv", checkIfExists: true)
+    }
 }
 
 def get_pre_fmx_cutoffs(library){
@@ -15,7 +19,11 @@ def get_pre_fmx_cutoffs(library){
 }
 
 def get_sobj(library){
-  return file("${params.project_dir}/data/single_cell_GEX/processed/${library}/automated_processing/${library}_raw.rds", checkIfExists: true)
+     if (params.settings.demux_method.equals("demuxlet")){
+        return file("${params.project_dir}/data/single_cell_GEX/processed/${library}/automated_processing_dmx/${library}_raw.rds", checkIfExists: true)
+    } else {
+      return file("${params.project_dir}/data/single_cell_GEX/processed/${library}/automated_processing/${library}_raw.rds", checkIfExists: true)
+    }
 }
 
 def get_pre_fmx_sobj(library){


### PR DESCRIPTION
To avoid overwriting, the output after demuxlet goes to `automated_processing_dmx` and `finding_doublets_dmx`. Logs now have the suffix `_dmx`. 

Next steps:

- [ ]  run both fmx and dmx in a single run