### PR TITLE
BugFix for inconsistent column order in gtcheck.out

### DIFF
--- a/single_cell_RNAseq/bin/examine_gtcheck.R
+++ b/single_cell_RNAseq/bin/examine_gtcheck.R
@@ -21,6 +21,14 @@ if (ncol(tab_in) == 6 & "CN" %in% tab_in$X1){ ### for 1.3.1
     filter(X6!=0, !str_detect(X3, "CLUST"), str_detect(X2, "CLUST")) %>%
     rename(individual=X3, cluster=X2, err=X4) %>%
     select(-X5, -X6)
+  # There is inconsistency in whether freemuxlet clusters fall into X2 or X3
+  if (nrow(my_tab)==0) {
+    my_tab = tab_in %>%
+      select(-X1) %>%
+      filter(X6!=0, !str_detect(X2, "CLUST"), str_detect(X3, "CLUST")) %>%
+      rename(individual=X2, cluster=X3, err=X4) %>%
+      select(-X5, -X6)
+  }
 } else if (ncol(tab_in)==7 & "DCv2" %in% tab_in$X1){ # 1.20
   my_tab = tab_in %>% 
     select(-X1) %>%


### PR DESCRIPTION
In the genotype matching step, I noticed my dataset had reversed column ordering compared to what the pipeline expected.  The pipeline expects freemuxlet clusters will exist in the 2nd column and sample ids will exist in the 3rd column of gtcheck.out files, but for me the sample ids were in column 2 and the freemuxlet clusters were in column 3.  Thinking there's inherent inconsistency, this PR adds an attempt to use the opposite ordering if the initial expectation yields 0 rows.

Note: Only touches the "1.18" version of the code