### PR TITLE
Improve doublet calculation logging, add option for running based on recovered

### DIFF
--- a/single_cell_RNAseq/README.md
+++ b/single_cell_RNAseq/README.md
@@ -60,6 +60,8 @@ The pipeline is designed to be run in either of 2 ways, and both involve an inte
 - Path 1 is the "standard" method, run with (1) step as `pre_qc`, (2) setting of cutoffs, then (3) step as `post_qc`.
 - Path 2 allows for QC filtering to be performed before freemuxlet/demuxlet which can be useful for tissue data, and is used with: (1) step as `pre_fmx_qc`, (2) setting of cutoffs, then (3) step as `post_fmx_qc`.
 
+(Note: we have also added a `df_auto` step to run doubletfinder and automating processing only. This is designed to be run only in special circumstances where the user decides to re-run only these steps. If you have run the pre_fmx path and reviewed cutoffs, it will complete. Otherwise, it will fail at the cutoff reviewing stage and you will need to complete with `post_qc`.)
+
 ### After run cleanup
 By default, the nextflow working directory will be:
 `/c4/scratch/<user>/nextflow/<original_job_id>`

--- a/single_cell_RNAseq/bin/find_doublets.R
+++ b/single_cell_RNAseq/bin/find_doublets.R
@@ -37,9 +37,10 @@ print_message(sprintf(
     MINFEATURE=%s
     MINCELL=%s
     RANDOMSEED=%s
+    USE_INTER_DBL_RATE=%s
     BASE_DIR=%s
   -----------
-  ", CELLR_H5_PATH, FMX_SAMPLE_PATH, SAMPLE, NCELLS_LOADED, MINFEATURE, MINCELL, RANDOMSEED, BASE_DIR)
+  ", CELLR_H5_PATH, FMX_SAMPLE_PATH, SAMPLE, NCELLS_LOADED, MINFEATURE, MINCELL, RANDOMSEED, USE_INTER_DBL_RATE, BASE_DIR)
 )
 
 
@@ -72,7 +73,7 @@ genDoubletTable = function(doublet_stats, ncells_loaded, nsamples){
     stat = c("ncells loaded", "ncells",  "predicted ncells recovered", "recovered (dbl + sng)", "nsamples",
             "DBL rate (10x based on ncells recovered)", "DBL rate (10x based on ncells loaded)",
             "FMX interDBL rate", "FMX intraDBL rate", "Recovered intraDBL rate", "Percent increase intraDBL rate (FMX vs Recovered)",
-             "Number of FMX DBL", "Remaining intra DBL (FMX)", "Doublets (10x recovered)", "Doublets (10x loaded)" ),
+             "Number of FMX DBL", "Remaining intra DBL (FMX)", "Doublets (10x recovered)", "Doublets (10x loaded)"),
     value = c(ncells_loaded, ncells, predicted_recovery, nrecovered, nsamples, 
       dbl_rate_10x_recovered, dbl_rate_10x_loaded, fmlDblRate, dblRateIntra, dblRateIntra_recovered, 
       (dblRateIntra-dblRateIntra_recovered)/dblRateIntra_recovered*100,
@@ -236,6 +237,7 @@ seuratObj@meta.data$DROPLET.TYPE.FINAL = ifelse(
   )
 
 tbl = table(seuratObj$DROPLET.TYPE.FINAL)
+seuratObj@misc$scStat$doublet_estimation_method_used=ifelse(USE_INTER_DBL_RATE=="true", "FMX", "recovered")
 seuratObj@misc$scStat$finalDropletTypeComp = as.matrix(tbl)
 seuratObj@misc$scStat$finalDropletTypeProp = as.matrix(prop.table(tbl))
 

--- a/single_cell_RNAseq/example-inputs/README.md
+++ b/single_cell_RNAseq/example-inputs/README.md
@@ -37,7 +37,8 @@ Note that comments cannot be included in json used for a run.
     "default_qc_cuts_file": "default_qc_cuts.csv", # default qc cuts file, see notes above about this
     "randomseed" : 21212, # random seed for reproducibility
     "remove_demux_DBL": true, # whether to remove free/demux doublets
-    "remove_all_DBL": true	# whether to remove all doublets (free/demux + doubletfinder)
+    "remove_all_DBL": true,	# whether to remove all doublets (free/demux + doubletfinder)
+    "user_inter_dbl_rate" : true # whether to use the DMX/FMX inter-individual doublet rate to estimate DBL for doublet finder, if false uses recovered number of cells
   },
   "pools" : [
     { "name" : "DM1", # name of the pool

--- a/single_cell_RNAseq/example-inputs/param_1.json
+++ b/single_cell_RNAseq/example-inputs/param_1.json
@@ -14,7 +14,8 @@
     "default_qc_cuts_file": "default_qc_cuts.csv",
     "randomseed": 21212,
     "remove_demux_DBL": true,
-    "remove_all_DBL": true
+    "remove_all_DBL": true,
+    "use_inter_dbl_rate": true
   },
   "pools": [
     {

--- a/single_cell_RNAseq/example-inputs/param_2.json
+++ b/single_cell_RNAseq/example-inputs/param_2.json
@@ -15,7 +15,8 @@
     "default_qc_cuts_file": "default_qc_cuts.csv",
     "randomseed" : 21212,
     "remove_demux_DBL": true,
-    "remove_all_DBL": true
+    "remove_all_DBL": true,
+    "use_inter_dbl_rate": true
   },
   "pools" : [
     {

--- a/single_cell_RNAseq/helpers/params_parse.nf
+++ b/single_cell_RNAseq/helpers/params_parse.nf
@@ -11,7 +11,12 @@ def get_cutoffs(library){
 }
 
 def get_pre_fmx_cutoffs(library){
-  return file("${params.project_dir}/data/single_cell_GEX/processed/${library}/cell_filter/${library}_cutoffs.csv", checkIfExists: true)
+  path = "${params.project_dir}/data/single_cell_GEX/processed/${library}/cell_filter/${library}_cutoffs.csv"
+  if (file(path).exists()){
+    return file(path, checkIfExists: true)
+  } else {
+    return(get_cutoffs(library))
+  }
 }
 
 def get_sobj(library){

--- a/single_cell_RNAseq/helpers/params_parse.nf
+++ b/single_cell_RNAseq/helpers/params_parse.nf
@@ -30,6 +30,15 @@ def get_c4_h5_bam(){
            }
     }
 }
+
+def get_c4_h5s(){
+    return params.pools.collectMany {
+           pool -> pool.libraries.collect {
+               library -> [library.name, get_c4_h5(library.name)]
+           }
+    }
+}
+
 def get_vdj_name(library, data_type){
   return library.replace("SCG", "SC" + data_type.substring(0, 1))
 }
@@ -45,6 +54,18 @@ def get_contigs(library, data_type){
   vdj_library=get_vdj_name(library, data_type)
   return file("${params.project_dir}/data/single_cell_${data_type}/processed/${vdj_library}/cellranger/all_contig_annotations.csv")
 }
+def get_sample_map(library){
+    return file("${params.project_dir}/data/single_cell_GEX/processed/${library}/${params.settings.demux_method}/${library}.clust1.samples.reduced.tsv")
+}
+
+def get_sample_maps(){
+    return params.pools.collectMany {
+           pool -> pool.libraries.collect {
+               library -> [library.name, get_sample_map(library.name)]
+           }
+    }
+}
+
 
 
 def get_pre_qc_outputs(){

--- a/single_cell_RNAseq/modules/pipeline_tasks.nf
+++ b/single_cell_RNAseq/modules/pipeline_tasks.nf
@@ -679,10 +679,10 @@ process FIND_DOUBLETS {
   echo "[\$(date '+%d/%m/%Y %H:%M:%S')]"
   echo "[running FIND_DOUBLETS]"
   echo " using container ${params.container.rsinglecell}"
-  echo " Rscript ${projectDir}/bin/find_doublets.R ${raw_h5} ${fmx_clusters} ${library} ${ncells_loaded} ${params.settings.minfeature} ${params.settings.mincell} ${params.settings.randomseed} ${params.use_inter_dbl_rate} ${projectDir}"
+  echo " Rscript ${projectDir}/bin/find_doublets.R ${raw_h5} ${fmx_clusters} ${library} ${ncells_loaded} ${params.settings.minfeature} ${params.settings.mincell} ${params.settings.randomseed} ${params.settings.use_inter_dbl_rate} ${projectDir}"
   echo "-----------"
   
-  Rscript ${projectDir}/bin/find_doublets.R ${raw_h5} ${fmx_clusters} ${library} ${ncells_loaded} ${params.settings.minfeature} ${params.settings.mincell} ${params.settings.randomseed} ${params.use_inter_dbl_rate} ${projectDir}
+  Rscript ${projectDir}/bin/find_doublets.R ${raw_h5} ${fmx_clusters} ${library} ${ncells_loaded} ${params.settings.minfeature} ${params.settings.mincell} ${params.settings.randomseed} ${params.settings.use_inter_dbl_rate} ${projectDir}
   
   """
 }

--- a/single_cell_RNAseq/modules/pipeline_tasks.nf
+++ b/single_cell_RNAseq/modules/pipeline_tasks.nf
@@ -679,10 +679,10 @@ process FIND_DOUBLETS {
   echo "[\$(date '+%d/%m/%Y %H:%M:%S')]"
   echo "[running FIND_DOUBLETS]"
   echo " using container ${params.container.rsinglecell}"
-  echo " Rscript ${projectDir}/bin/find_doublets.R ${raw_h5} ${fmx_clusters} ${library} ${ncells_loaded} ${params.settings.minfeature} ${params.settings.mincell} ${params.settings.randomseed} ${projectDir}"
+  echo " Rscript ${projectDir}/bin/find_doublets.R ${raw_h5} ${fmx_clusters} ${library} ${ncells_loaded} ${params.settings.minfeature} ${params.settings.mincell} ${params.settings.randomseed} ${params.use_inter_dbl_rate} ${projectDir}"
   echo "-----------"
   
-  Rscript ${projectDir}/bin/find_doublets.R ${raw_h5} ${fmx_clusters} ${library} ${ncells_loaded} ${params.settings.minfeature} ${params.settings.mincell} ${params.settings.randomseed} ${projectDir}
+  Rscript ${projectDir}/bin/find_doublets.R ${raw_h5} ${fmx_clusters} ${library} ${ncells_loaded} ${params.settings.minfeature} ${params.settings.mincell} ${params.settings.randomseed} ${params.use_inter_dbl_rate} ${projectDir}
   
   """
 }

--- a/single_cell_RNAseq/modules/pipeline_tasks.nf
+++ b/single_cell_RNAseq/modules/pipeline_tasks.nf
@@ -676,13 +676,22 @@ process FIND_DOUBLETS {
   path(".command.log"), emit: log
 
   """
+  arr="${params.settings}"
+  if [[ \${arr} == *"use_inter_dbl_rate"* ]];
+  then
+    use_inter_dbl_rate=${params.settings.use_inter_dbl_rate}
+  else
+    echo "'use_inter_dbl_rate' parameter not found, defaulting to true"
+    use_inter_dbl_rate="true"
+  fi
+
   echo "[\$(date '+%d/%m/%Y %H:%M:%S')]"
   echo "[running FIND_DOUBLETS]"
   echo " using container ${params.container.rsinglecell}"
-  echo " Rscript ${projectDir}/bin/find_doublets.R ${raw_h5} ${fmx_clusters} ${library} ${ncells_loaded} ${params.settings.minfeature} ${params.settings.mincell} ${params.settings.randomseed} ${params.settings.use_inter_dbl_rate} ${projectDir}"
+  echo " Rscript ${projectDir}/bin/find_doublets.R ${raw_h5} ${fmx_clusters} ${library} ${ncells_loaded} ${params.settings.minfeature} ${params.settings.mincell} ${params.settings.randomseed} \${use_inter_dbl_rate} ${projectDir}"
   echo "-----------"
   
-  Rscript ${projectDir}/bin/find_doublets.R ${raw_h5} ${fmx_clusters} ${library} ${ncells_loaded} ${params.settings.minfeature} ${params.settings.mincell} ${params.settings.randomseed} ${params.settings.use_inter_dbl_rate} ${projectDir}
+  Rscript ${projectDir}/bin/find_doublets.R ${raw_h5} ${fmx_clusters} ${library} ${ncells_loaded} ${params.settings.minfeature} ${params.settings.mincell} ${params.settings.randomseed} \${use_inter_dbl_rate} ${projectDir}
   
   """
 }

--- a/single_cell_RNAseq/pipeline_df_auto.nf
+++ b/single_cell_RNAseq/pipeline_df_auto.nf
@@ -24,8 +24,8 @@ SEURAT_POST_FILTER
 
 include {
 get_c4_h5; get_library_ncells; get_libraries_data_type_tuples;
-get_vdj_tuple; get_vdj_name ; get_clonotypes; get_contigs; get_pre_fmx_qc_outputs;
-get_pre_fmx_cutoffs ; get_sample_map; get_sample_maps; get_c4_h5s
+get_vdj_tuple; get_vdj_name; get_clonotypes; get_contigs; get_pre_fmx_qc_outputs;
+get_pre_fmx_cutoffs; get_cutoffs; get_sample_map; get_sample_maps; get_c4_h5s
 } from  './helpers/params_parse.nf'
 
 
@@ -99,7 +99,7 @@ workflow {
      */
      ch_library_info = Channel.from(get_libraries_data_type_tuples()).transpose() // -> [[library_dir, data_type]]
      ch_seurat_input = ch_library_info.join(ch_bcr_out) // -> [library, data_type, ]
-      .map{it -> [it[0], it[1], it[2], get_c4_h5(it[0]), get_pre_fmx_cutoffs(it[0])] }
+     .map{it -> [it[0], it[1], it[2], get_c4_h5(it[0]), get_pre_fmx_cutoffs(it[0])] } // pre_fmx
      SEURAT_LOAD_POST_QC(ch_seurat_input)
 
       // use cutoffs listed prior

--- a/single_cell_RNAseq/pipeline_df_auto.nf
+++ b/single_cell_RNAseq/pipeline_df_auto.nf
@@ -1,0 +1,113 @@
+
+
+nextflow.enable.dsl=2
+
+workflow.onComplete {
+    println "Pipeline completed at: $workflow.complete"
+    println "Execution status: ${ workflow.success ? 'OK' : 'failed' }"
+    if (workflow.success){
+       println "Deleting working directory $workDir"
+       "rm -rf $workDir".execute()
+    }
+}
+
+
+include { 
+FIND_DOUBLETS;
+LOAD_SOBJ;
+SEURAT_ADD_BCR;
+SEURAT_ADD_TCR;
+SEURAT_LOAD_POST_QC;
+SEURAT_POST_FILTER
+} from './modules/pipeline_tasks.nf'
+
+
+include {
+get_c4_h5; get_library_ncells; get_libraries_data_type_tuples;
+get_vdj_tuple; get_vdj_name ; get_clonotypes; get_contigs; get_pre_fmx_qc_outputs;
+get_pre_fmx_cutoffs ; get_sample_map; get_sample_maps; get_c4_h5s
+} from  './helpers/params_parse.nf'
+
+
+include {
+extractFileName
+} from "./helpers/utils.nf"
+ 
+
+
+workflow {
+
+
+    ch_all_h5 = Channel.fromList(get_c4_h5s())
+ 
+    ch_sample_map = Channel.fromList(get_sample_maps())
+
+      /*
+      --------------------------------------------------------
+      Run doublet finder if specified
+      --------------------------------------------------------
+      */
+     ch_initial_sobj = Channel.empty()
+     if (params.settings.run_doubletfinder) {
+        ch_doublet_input = Channel.from(get_library_ncells()).join(ch_all_h5).join(ch_sample_map) // [lib, ncells, raw_h5, fmx_cluster ]
+        FIND_DOUBLETS(ch_doublet_input) // --> [lib, doublet_finder_sobj]
+        ch_initial_sobj = FIND_DOUBLETS.out.sobj
+     } else {
+        ch_doublet_input = ch_all_h5.join(ch_sample_map) // [lib, ncells, raw_h5, fmx_cluster]
+        LOAD_SOBJ(ch_doublet_input)
+        ch_initial_sobj = LOAD_SOBJ.out.sobj
+     }
+     
+      /* 
+      --------------------------------------------------------
+      Set up seurat object
+      --------------------------------------------------------
+      */
+      // add TCR & BCR data
+      
+             ch_library_bcr_tcr = Channel.from(get_libraries_data_type_tuples()).transpose().filter { it[1] in ["BCR", "TCR"] }
+                
+              ch_vdj_libs = ch_library_bcr_tcr
+              .map{
+                it -> [it[0], it[1], get_clonotypes(it[0], it[1]), get_contigs(it[0], it[1])]
+              }
+              .branch { 
+                        tcr: it[1].contains("TCR")
+                        bcr: it[1].contains("BCR")
+                    }  
+
+
+
+     if (params.settings.add_tcr){
+        SEURAT_ADD_TCR(ch_initial_sobj.join(ch_vdj_libs.tcr, by:0, remainder: true))
+        ch_tcr_out = SEURAT_ADD_TCR.out.sobj
+      } else {
+        ch_tcr_out = ch_initial_sobj
+      }
+
+      if (params.settings.add_bcr){
+        SEURAT_ADD_BCR(ch_tcr_out.join(ch_vdj_libs.bcr, by:0, remainder: true))
+        ch_bcr_out = SEURAT_ADD_BCR.out.sobj
+      } else {
+        ch_bcr_out = ch_tcr_out
+      } 
+
+     /*
+     --------------------------------------------------------
+     Set up seurat object
+     --------------------------------------------------------
+     */
+     ch_library_info = Channel.from(get_libraries_data_type_tuples()).transpose() // -> [[library_dir, data_type]]
+     ch_seurat_input = ch_library_info.join(ch_bcr_out) // -> [library, data_type, ]
+      .map{it -> [it[0], it[1], it[2], get_c4_h5(it[0]), get_pre_fmx_cutoffs(it[0])] }
+     SEURAT_LOAD_POST_QC(ch_seurat_input)
+
+      // use cutoffs listed prior
+      ch_seurat_post_qc_in = SEURAT_LOAD_POST_QC.out.cutoffs_file // -> [library, cutoffs]
+          .combine(SEURAT_LOAD_POST_QC.out.qc_output, by:0) // -> [library, cutoffs, sobj
+          .map{it -> [it[0], it[1], it[2], get_c4_h5(it[0])] } // -> [library, cutoffs, sobj, cr_h5]
+      SEURAT_POST_FILTER(ch_seurat_post_qc_in)
+
+}
+
+

--- a/single_cell_RNAseq/run.sh
+++ b/single_cell_RNAseq/run.sh
@@ -26,10 +26,10 @@ then
  failed=true;
 fi
 
-VALID_STEPS=("pre_qc post_qc pre_fmx_qc post_fmx_qc")
+VALID_STEPS=("pre_qc post_qc pre_fmx_qc post_fmx_qc df_auto")
 if [[ ! " ${VALID_STEPS[*]} " =~ " ${STEP} " ]];
 then
-  echo "please include a valid step as the second argument -- must be one of 'pre_qc', 'post_qc', 'pre_fmx_qc', 'post_fmx_qc'"
+  echo "please include a valid step as the second argument -- must be one of 'pre_qc', 'post_qc', 'pre_fmx_qc', 'post_fmx_qc', 'df_auto'"
   failed=true;
 fi
 

--- a/single_cell_RNAseq/run_resume.sh
+++ b/single_cell_RNAseq/run_resume.sh
@@ -31,10 +31,10 @@ then
 fi
 
 
-VALID_STEPS=("pre_qc post_qc pre_fmx_qc post_fmx_qc")
+VALID_STEPS=("pre_qc post_qc pre_fmx_qc post_fmx_qc df_auto")
 if [[ ! " ${VALID_STEPS[*]} " =~ " ${STEP} " ]];
 then
-  echo "please include a valid step as the second argument -- must be one of 'pre_qc', 'post_qc', 'pre_fmx_qc', 'post_fmx_qc'"
+  echo "please include a valid step as the second argument -- must be one of 'pre_qc', 'post_qc', 'pre_fmx_qc', 'post_fmx_qc', 'df_auto'"
   failed=true;
 fi
 


### PR DESCRIPTION
Modifications:
- updates/adds logging information to the doublet stats tsv to compare predicted / expected DBL rate 
- fixes a doublet stat calculation for logging tsv (does not change any doublet-related calculation, just log) to use num_sng + num_dbl instead of num_sng
- adds parameter `use_inter_dbl_rate` to allow users to specify to use the default (true, demultiplexing-based doublet rate) or ncells recovered for the doublet rate. Still works if it this parameter is not included.
- adds code to allow for ncells recovered calculation
- adds optional `df_auto` pipeline for just running doublet_finder and automated_processing